### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "stylelint-config-ccb",
   "version": "3.32.0",
+  "bugs": {
+    "url": "https://github.com/carlosjeurissen/stylelint-config-ccb/issues"
+  },
   "description": "Stylelint config which extends stylelint-config-standard",
   "keywords": [
     "stylelint",


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.